### PR TITLE
NAV-24639: Fikser feilende test pga dato formatering

### DIFF
--- a/src/app/api/barnetrygd/route.test.ts
+++ b/src/app/api/barnetrygd/route.test.ts
@@ -37,7 +37,7 @@ describe('Barnetrygd Route', () => {
                     {
                         barnetrygd: {
                             ordinær: {
-                                startmåned: '10/2025',
+                                startmåned: '2024-10',
                             },
                         },
                     },
@@ -52,7 +52,7 @@ describe('Barnetrygd Route', () => {
 
         // Expect
         expect(response.status).toBe(200);
-        expect(dto.barnetrygd?.ordinær?.startmåned).toBe('10/2025');
+        expect(dto.barnetrygd?.ordinær?.startmåned).toBe('2024-10');
         expect(dto.barnetrygd?.utvidet).toBeUndefined();
     });
 


### PR DESCRIPTION
Favro: [NAV-24639](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24639)

Fikser feilende test pga. formatering av dato. Ser ut som det forrige bygget gikk grønt selv om det var en typescript feil, veldig rart. 🤔 