### PR TITLE
Legger til generell feilmeldingsside og not-found-side.

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { Seksjon } from '@/komponenter/Seksjon';
+import { BodyShort, Button, Heading, Link, List, VStack } from '@navikt/ds-react';
+
+export default function Error() {
+    return (
+        <Seksjon>
+            <Seksjon.Innhold>
+                <VStack gap="16">
+                    <VStack align="start" gap="12">
+                        <div>
+                            <Heading level="1" size="large" spacing>
+                                Beklager, noe gikk galt
+                            </Heading>
+                            <BodyShort spacing>
+                                En teknisk feil på våre servere gjør at siden er utilgjengelig.
+                                Dette skyldes ikke noe du gjorde.
+                            </BodyShort>
+                            <BodyShort>Du kan prøve å</BodyShort>
+                            <List>
+                                <List.Item>
+                                    vente noen minutter og{' '}
+                                    <Link href="#" onClick={() => location.reload()}>
+                                        laste siden på nytt
+                                    </Link>
+                                </List.Item>
+                                {window.history.length > 1 && (
+                                    <List.Item>
+                                        <Link href="#" onClick={() => history.back()}>
+                                            gå tilbake til forrige side
+                                        </Link>
+                                    </List.Item>
+                                )}
+                            </List>
+                            <BodyShort>
+                                Hvis problemet vedvarer, kan du{' '}
+                                <Link href="https://nav.no/kontaktoss" target="_blank">
+                                    kontakte oss (åpnes i ny fane)
+                                </Link>
+                                .
+                            </BodyShort>
+                        </div>
+                        <Button as="a" href={'/barnetrygd/min-barnetrygd'}>
+                            Gå til Min side
+                        </Button>
+                    </VStack>
+                    <VStack align="start">
+                        <Heading level="1" size="large" spacing>
+                            Something went wrong
+                        </Heading>
+                        <BodyShort spacing>
+                            This was caused by a technical fault on our servers. Please refresh this
+                            page or try again in a few minutes.
+                        </BodyShort>
+                        <BodyShort>
+                            <Link href="https://www.nav.no/kontaktoss/en" target="_blank">
+                                Contact us (opens in a new tab)
+                            </Link>{' '}
+                            if the problem persists.
+                        </BodyShort>
+                    </VStack>
+                </VStack>
+            </Seksjon.Innhold>
+        </Seksjon>
+    );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { Seksjon } from '@/komponenter/Seksjon';
+import { BodyShort, Button, Heading, Link, List, VStack } from '@navikt/ds-react';
+import { BugIcon } from '@navikt/aksel-icons';
+import { usePathname } from 'next/navigation';
+
+export default function NotFound() {
+    const pathname = usePathname();
+    return (
+        <Seksjon>
+            <Seksjon.Innhold>
+                <VStack gap="16">
+                    <VStack align="start" gap="12">
+                        <div>
+                            <Heading level="1" size="large" spacing>
+                                Beklager, vi fant ikke siden
+                            </Heading>
+                            <BodyShort spacing>
+                                Denne siden kan være slettet eller flyttet, eller det er en feil i
+                                lenken.
+                            </BodyShort>
+                            <List>
+                                <List.Item>Bruk gjerne søket eller menyen</List.Item>
+                                <List.Item>
+                                    <Link href="https://nav.no">Gå til forsiden</Link>
+                                </List.Item>
+                            </List>
+                        </div>
+                        <Button as="a" href="/barnetrygd">
+                            Gå til Min side
+                        </Button>
+                        <Link
+                            href={`https://github.com/navikt/familie-ba-minside-frontend/issues/new?assignees=&labels=bug+%F0%9F%90%9B&projects=&template=bug-report.md&title=[${pathname}%20-%20404]`}
+                        >
+                            <BugIcon aria-hidden />
+                            Meld gjerne fra om at lenken ikke virker
+                        </Link>
+                    </VStack>
+                    <VStack align="start">
+                        <Heading level="1" size="large" spacing>
+                            Page not found
+                        </Heading>
+                        <BodyShort spacing>The page you requested cannot be found.</BodyShort>
+                        <BodyShort>
+                            Go to the <Link href="/barnetrygd">front page</Link>, or use one of the
+                            links in the menu.
+                        </BodyShort>
+                    </VStack>
+                </VStack>
+            </Seksjon.Innhold>
+        </Seksjon>
+    );
+}


### PR DESCRIPTION
[Favro-kort: NAV-25709 Generell feilmelding for hele innlogget side](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25709)

Legger til to sider som skal fange opp feilmeldinger:
- En generell error-side i henhold til mal: [Aksel mal 5xx-side](https://aksel.nav.no/monster-maler/stotte/5xx-side)
<img width="868" height="565" alt="image" src="https://github.com/user-attachments/assets/e6c0c755-2ee0-4d86-bd54-c04fa316333e" />

Siden har jeg fått opp for testing ved å gå inn i koden og kaste en feil på siden.

- En 404 Not Found side i henhold til mal: [Aksel mal 404-side](https://aksel.nav.no/monster-maler/stotte/404-side)
<img width="696" height="590" alt="image" src="https://github.com/user-attachments/assets/b42c2630-73c7-481a-b194-3648cca0bd9d" />

Siden fremprovoseres ved å prøve å skrive en url som ikke fører til en gyldig side. 

Lenken for å melde i fra om at lenken ikke virker er tatt inspirasjon fra [Aksel sin eksempel 404-side
](https://aksel.nav.no/dette-er-en-404-side) som lenker til en ny PR i repo, så jeg har satt til dette repoet med navn som er pathname.

