### PR TITLE
Erstatter hardkodet url med uthenting av url per miljø

### DIFF
--- a/src/app/api/dokument/route.ts
+++ b/src/app/api/dokument/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { hentOboToken } from '@/server/auth/hentOboToken';
 import { OboTokenResponse } from '@/server/auth/typer/OboTokenResponse';
 import { v4 as uuid } from 'uuid';
-import { erProd } from '@/util/miljø';
+import { erProd, hentFamilieIntegrasjonerBaseUrl } from '@/util/miljø';
 
 export async function GET(req: NextRequest) {
     const oboToken: OboTokenResponse = await hentOboToken(
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest) {
     const dokumentInfoId = req.nextUrl.searchParams.get('dokumentInfoId');
     const journalpostId = req.nextUrl.searchParams.get('journalpostId');
 
-    const url = `https://familie-integrasjoner.dev-fss-pub.nais.io/api/journalpostselvbetjening/${journalpostId}/dokument/${dokumentInfoId}`;
+    const url = `${hentFamilieIntegrasjonerBaseUrl()}/api/journalpostselvbetjening/${journalpostId}/dokument/${dokumentInfoId}`;
 
     const response = await fetch(url, {
         headers: {

--- a/src/app/api/dokumenter/route.ts
+++ b/src/app/api/dokumenter/route.ts
@@ -4,7 +4,7 @@ import { Dokumentoversikt, Journalpost } from '@/typer/api/dokumentoversikt';
 import { OboTokenResponse } from '@/server/auth/typer/OboTokenResponse';
 import { hentOboToken } from '@/server/auth/hentOboToken';
 import { v4 as uuid } from 'uuid';
-import { erProd } from '@/util/miljø';
+import { erProd, hentFamilieIntegrasjonerBaseUrl } from '@/util/miljø';
 
 export async function GET(req: NextRequest) {
     const oboToken: OboTokenResponse = await hentOboToken(
@@ -14,8 +14,7 @@ export async function GET(req: NextRequest) {
     if (!oboToken.ok) {
         return new NextResponse(oboToken.error, { status: 401 });
     }
-    const url =
-        'https://familie-integrasjoner.dev-fss-pub.nais.io/api/journalpostselvbetjening/dokumentoversikt/BAR';
+    const url = `${hentFamilieIntegrasjonerBaseUrl()}/api/journalpostselvbetjening/dokumentoversikt/BAR`;
 
     const response = await fetch(url, {
         headers: {

--- a/src/util/miljø.ts
+++ b/src/util/miljø.ts
@@ -50,3 +50,11 @@ export function hentFamilieBaSakBaseUrl(): string {
     }
     return 'http://localhost:8089';
 }
+
+export function hentFamilieIntegrasjonerBaseUrl(): string {
+    if (erProd()) {
+        return 'https://familie-integrasjoner.prod-fss-pub.nais.io';
+    } else {
+        return 'https://familie-integrasjoner.dev-fss-pub.nais.io';
+    }
+}


### PR DESCRIPTION
Vi hadde hardkodet urlen til familie-integrasjoner. Dette fikser biffen.